### PR TITLE
File upload workflow

### DIFF
--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -5,142 +5,153 @@ on:
     branches:
       - '**'
     paths:
-      - ./data/
+      - data/
       
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows running workflow manually from Actions tab
   workflow_dispatch:
 
 jobs:
 # Placeholder
-#   build-bmd:
-#     #if: github.actor != 'github-actions[bot]'
-#     runs-on: ubuntu-20.04
-#     environment: build
-#     steps:
-#       - name: Checkout Repo
-#         uses: actions/checkout@v3
-#       - name: Download artifacts from previous drug gen
-#         uses: actions/download-artifact@v4
-#       - name: Pull sample image
-#         run: docker pull sgosline/srp-bmd
-#       - name: Run bmd python command
-#         run: |
-#           docker run -v $PWD:/tmp sgosline/srp-bmd
-#       - name: List files cwd
-#         run: ls -la
-   build-samples:
-     #if: github.actor != 'github-actions[bot]'
-     runs-on: ubuntu-20.04
-     steps:
-       - name: Checkout Repo
-         uses: actions/checkout@v3
-       - name: Download artifacts from previous drug gen
-         uses: actions/download-artifact@v4
-       - name: Pull sample image
-         run: docker pull sgosline/srp-samplechem
-       - name: Run sample-chem python command
-         run: |
-           docker run -v $PWD:/tmp sgosline/srp-samplechem 
-       - name: List files cwd
-         run: ls -la
-       - name: move files
-         run: |
-           mkdir samp-files
-           mv *csv samp-files
-       - name: upload artifacts
-         uses: actions/upload-artifact@v4
-         with:
-           name: samp-files
-           path: samp-files
-   build-expo:
-     #if: github.actor != 'github-actions[bot]'
-     runs-on: ubuntu-20.04
-     steps:
-       - name: Checkout Repo
-         uses: actions/checkout@v3
-       - name: Download artifacts from previous drug gen
-         uses: actions/download-artifact@v4
-       - name: Pull sample image
-         run: docker pull sgosline/srp-exposome
-       - name: Run sample-chem python command
-         run: |
-           docker run -v $PWD:/tmp sgosline/srp-exposome
-       - name: List files cwd
-         run: ls -la 
-       - name: Copy files to artifact
-         run: |
-           mkdir expo-files
-           mv *.csv expo-files
-       - name: upload artifact
-         uses: actions/upload-artifact@v4
-         with:
-           name: expo-files
-           path: expo-files         
+  build-bmd:
+    #if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-20.04
+    # environment: build
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Download artifacts from previous drug gen
+        uses: actions/download-artifact@v4
+      - name: Pull sample image
+        run: docker pull sgosline/srp-bmd
+      - name: Run bmd python command
+        run: |
+          docker run -v $PWD:/tmp sgosline/srp-bmd --morpho /app/zfBmd/test_files/test_morphology.csv --lpr /app/zfBmd/test_files/test_behavioral.csv --output /tmp
+      - name: List files cwd
+        run: ls -la
+      - name: Move files
+        run: |
+          mkdir bmd-files
+          mv *.csv bmd-files
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bmd-files
+          path: bmd-files
+          
+  build-samples:
+    #if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Download artifacts from previous drug gen
+        uses: actions/download-artifact@v4
+      - name: Pull sample image
+        run: docker pull sgosline/srp-samplechem
+      - name: Run sample-chem python command
+        run: |
+          docker run -v $PWD:/tmp sgosline/srp-samplechem 
+      - name: List files cwd
+        run: ls -la
+      - name: Move files
+        run: |
+          mkdir samp-files
+          mv *csv samp-files
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: samp-files
+          path: samp-files
 
-   build-expr:
-     #if: github.actor != 'github-actions[bot]'
-     runs-on: ubuntu-20.04
-     needs: build-samples
-     steps:
-       - name: Checkout Repo
-         uses: actions/checkout@v3
-       - name: Download artifacts from sample generation
-         uses: actions/download-artifact@v4
-         with:
-           name: samp-files
-           path: samp-files
-       - name: Pull sample image
-         run: docker pull sgosline/srp-zfexp
-       - name: move chemical list to tmp
-         run: mv samp-files/chemicals.csv .
-       - name: Run zfexp python command
-         run: |
-           docker run -v $PWD:/tmp sgosline/srp-zfexp
-       - name: List files cwd
-         run: ls -la 
-       - name: Copy files to artifact
-         run: |
-           mkdir expr-files
-           mv *csv expr-files
-       - name: upload artifact
-         uses: actions/upload-artifact@v4
-         with:
-           name: expr-files
-           path: expr-files
+  build-expo:
+    #if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Download artifacts from previous drug gen
+        uses: actions/download-artifact@v4
+      - name: Pull sample image
+        run: docker pull sgosline/srp-exposome
+      - name: Run sample-chem python command
+        run: |
+          docker run -v $PWD:/tmp sgosline/srp-exposome
+      - name: List files cwd
+        run: ls -la 
+      - name: Copy files to artifact
+        run: |
+          mkdir expo-files
+          mv *.csv expo-files
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expo-files
+          path: expo-files         
 
-   artifact-test:
-     needs: [build-samples,build-expo,build-expr]
-     runs-on: ubuntu-20.04
-     steps:
-       - name: Checkout Repo
-         uses: actions/checkout@v2
-       - name: Download artifacts from expression
-         uses: actions/download-artifact@v4
-         with:
-           name: expr-files
-       - name: Downlod artifacts from exposome
-         uses: actions/download-artifact@v4
-         with:
-           name: expo-files
-       - name: Downlod artifacts from samples
-         uses: actions/download-artifact@v4
-         with:
-           name: samp-files
-       - name: List files cwd
-         run: ls -la *
-       - name: Moves files to single directory
-         run: |
-           mkdir srpAnalytics
-           mv *csv srpAnalytics
-           #gzip -cvf srpAnalytics/* srpAnalytics.gz
-       - name: Pushes to figshare
-         uses: figshare/github-upload-action@v1.1
-         with:
-           FIGSHARE_TOKEN: ${{ secrets.FIGSHARE_TOKEN }}
-           FIGSHARE_ENDPOINT: 'https://api.figshare.com/v2'
-           FIGSHARE_ARTICLE_ID: 26240471
-#           FIGSHARE_PROJECT_ID: 177459
-           DATA_DIR: 'srpAnalytics'
+  build-expr:
+    #if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-20.04
+    needs: build-samples
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Download artifacts from sample generation
+        uses: actions/download-artifact@v4
+        with:
+          name: samp-files
+          path: samp-files
+      - name: Pull sample image
+        run: docker pull sgosline/srp-zfexp
+      - name: move chemical list to tmp
+        run: mv samp-files/chemicals.csv .
+      - name: Run zfexp python command
+        run: |
+          docker run -v $PWD:/tmp sgosline/srp-zfexp
+      - name: List files cwd
+        run: ls -la 
+      - name: Copy files to artifact
+        run: |
+          mkdir expr-files
+          mv *.csv expr-files
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expr-files
+          path: expr-files
+
+  artifact-test:
+    needs: [build-samples, build-expo, build-expr]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Download artifacts from expression
+        uses: actions/download-artifact@v4
+        with:
+          name: expr-files
+      - name: Download artifacts from exposome
+        uses: actions/download-artifact@v4
+        with:
+          name: expo-files
+      - name: Download artifacts from samples
+        uses: actions/download-artifact@v4
+        with:
+          name: samp-files
+      - name: List files cwd
+        run: ls -la *
+      - name: Moves files to single directory
+        run: |
+          mkdir srpAnalytics
+          mv *.csv srpAnalytics
+          # gzip -cvf srpAnalytics/* srpAnalytics.gz
+      - name: Pushes to figshare
+        uses: figshare/github-upload-action@v1.1
+        with:
+          FIGSHARE_TOKEN: ${{ secrets.FIGSHARE_TOKEN }}
+          FIGSHARE_ENDPOINT: 'https://api.figshare.com/v2'
+          FIGSHARE_ARTICLE_ID: 26240471
+  #           FIGSHARE_PROJECT_ID: 177459
+          DATA_DIR: 'srpAnalytics'
 
 #zipfiles push to figshare
 

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -120,11 +120,15 @@ jobs:
           path: expr-files
 
   artifact-test:
-    needs: [build-samples, build-expo, build-expr]
+    needs: [build-bmd, build-samples, build-expo, build-expr]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Download artifacts from bmd
+        uses: actions/download-artifact@v4
+        with:
+          name: bmd-files
       - name: Download artifacts from expression
         uses: actions/download-artifact@v4
         with:
@@ -146,6 +150,7 @@ jobs:
           # gzip -cvf srpAnalytics/* srpAnalytics.gz
       - name: Pushes to figshare
         uses: figshare/github-upload-action@v1.1
+        continue-on-error: true
         with:
           FIGSHARE_TOKEN: ${{ secrets.FIGSHARE_TOKEN }}
           FIGSHARE_ENDPOINT: "https://api.figshare.com/v2"

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -138,7 +138,7 @@ jobs:
             "title": "SRP Analytics Database - ${TIMESTAMP}",
             "description": "Testing automated database build from commit ${COMMIT_SHA} on branch ${BRANCH_NAME}. Generated on ${TIMESTAMP}.",
             "tags": ["srp-analytics", "database", "automated", "github-actions", "private"],
-            "categories": [1],
+            "categories": [26965, 26968],
             "authors": [{"name": "SRP Analytics Pipeline"}],
             "defined_type": "dataset"
           }

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -3,18 +3,18 @@ name: Build-database
 on:
   push:
     branches:
-      - '**'
+      - "**"
     paths:
       - data/
-      
+
   # Allows running workflow manually from Actions tab
   workflow_dispatch:
 
 jobs:
-# Placeholder
+  # Placeholder
   build-bmd:
     #if: github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # environment: build
     steps:
       - name: Checkout Repo
@@ -37,10 +37,10 @@ jobs:
         with:
           name: bmd-files
           path: bmd-files
-          
+
   build-samples:
     #if: github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
         run: docker pull sgosline/srp-samplechem
       - name: Run sample-chem python command
         run: |
-          docker run -v $PWD:/tmp sgosline/srp-samplechem 
+          docker run -v $PWD:/tmp sgosline/srp-samplechem
       - name: List files cwd
         run: ls -la
       - name: Move files
@@ -65,7 +65,7 @@ jobs:
 
   build-expo:
     #if: github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
         run: |
           docker run -v $PWD:/tmp sgosline/srp-exposome
       - name: List files cwd
-        run: ls -la 
+        run: ls -la
       - name: Copy files to artifact
         run: |
           mkdir expo-files
@@ -86,11 +86,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: expo-files
-          path: expo-files         
+          path: expo-files
 
   build-expr:
     #if: github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build-samples
     steps:
       - name: Checkout Repo
@@ -108,7 +108,7 @@ jobs:
         run: |
           docker run -v $PWD:/tmp sgosline/srp-zfexp
       - name: List files cwd
-        run: ls -la 
+        run: ls -la
       - name: Copy files to artifact
         run: |
           mkdir expr-files
@@ -121,7 +121,7 @@ jobs:
 
   artifact-test:
     needs: [build-samples, build-expo, build-expr]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -148,10 +148,9 @@ jobs:
         uses: figshare/github-upload-action@v1.1
         with:
           FIGSHARE_TOKEN: ${{ secrets.FIGSHARE_TOKEN }}
-          FIGSHARE_ENDPOINT: 'https://api.figshare.com/v2'
+          FIGSHARE_ENDPOINT: "https://api.figshare.com/v2"
           FIGSHARE_ARTICLE_ID: 26240471
-  #           FIGSHARE_PROJECT_ID: 177459
-          DATA_DIR: 'srpAnalytics'
-
+          #           FIGSHARE_PROJECT_ID: 177459
+          DATA_DIR: "srpAnalytics"
 #zipfiles push to figshare
 

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -119,8 +119,59 @@ jobs:
           name: expr-files
           path: expr-files
 
+  create-figshare-article:
+    runs-on: ubuntu-latest
+    outputs:
+      article_id: ${{ steps.create_article.outputs.article_id }}
+    steps:
+      - name: Create new private Figshare article
+        id: create_article
+        run: |
+          # Generate timestamp for unique article title
+          TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+          COMMIT_SHA="${{ github.sha }}"
+          BRANCH_NAME="${{ github.ref_name }}"
+
+          # Create article metadata
+          ARTICLE_DATA=$(cat <<EOF
+          {
+            "title": "SRP Analytics Database - ${TIMESTAMP}",
+            "description": "Testing automated database build from commit ${COMMIT_SHA} on branch ${BRANCH_NAME}. Generated on ${TIMESTAMP}.",
+            "tags": ["srp-analytics", "database", "automated", "github-actions", "private"],
+            "categories": [1],
+            "authors": [{"name": "SRP Analytics Pipeline"}],
+            "defined_type": "dataset"
+          }
+          EOF
+          )
+
+          # Create the article (private by default)
+          RESPONSE=$(curl -s -X POST \
+            -H "Authorization: token ${{ secrets.FIGSHARE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "$ARTICLE_DATA" \
+            "https://api.figshare.com/v2/account/articles")
+
+          # Extract article ID
+          ARTICLE_ID=$(echo "$RESPONSE" | jq -r '.entity_id')
+
+          if [ "$ARTICLE_ID" = "null" ] || [ -z "$ARTICLE_ID" ]; then
+            echo "Failed to create article. Response: $RESPONSE"
+            exit 1
+          fi
+
+          echo "Created Figshare article with ID: $ARTICLE_ID"
+          echo "article_id=$ARTICLE_ID" >> $GITHUB_OUTPUT
+
   artifact-test:
-    needs: [build-bmd, build-samples, build-expo, build-expr]
+    needs:
+      [
+        build-bmd,
+        build-samples,
+        build-expo,
+        build-expr,
+        create-figshare-article,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -154,8 +205,9 @@ jobs:
         with:
           FIGSHARE_TOKEN: ${{ secrets.FIGSHARE_TOKEN }}
           FIGSHARE_ENDPOINT: "https://api.figshare.com/v2"
-          FIGSHARE_ARTICLE_ID: 26240471
-          #           FIGSHARE_PROJECT_ID: 177459
+          FIGSHARE_ARTICLE_ID: ${{ needs.create-figshare-article.outputs.article_id }}
+          # FIGSHARE_ARTICLE_ID: 26240471
+          # FIGSHARE_PROJECT_ID: 177459
           DATA_DIR: "srpAnalytics"
 #zipfiles push to figshare
 

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Download artifacts from previous drug gen
         uses: actions/download-artifact@v4
       - name: Pull sample image
-        run: docker pull sgosline/srp-bmd
+        run: docker pull sgosline/srp-zfbmd
       - name: Run bmd python command
         run: |
           docker run -v $PWD:/tmp sgosline/srp-zfbmd --morpho /app/zfBmd/test_files/test_morphology.csv --lpr /app/zfBmd/test_files/test_behavioral.csv --output /tmp

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -131,13 +131,14 @@ jobs:
           TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
           COMMIT_SHA="${{ github.sha }}"
           BRANCH_NAME="${{ github.ref_name }}"
+          FIGSHARE_PROJECT_ID="${{ secrets.FIGSHARE_PROJECT_ID }}"
 
-          # Create article metadata
+          # Define article metadata
           ARTICLE_DATA=$(cat <<EOF
           {
             "title": "SRP Analytics Database - ${TIMESTAMP}",
             "description": "Testing automated database build from commit ${COMMIT_SHA} on branch ${BRANCH_NAME}. Generated on ${TIMESTAMP}.",
-            "tags": ["srp-analytics", "database", "automated", "github-actions", "private"],
+            # "tags": ["srp-analytics", "database"],
             "categories": [26965, 26968],
             "authors": [{"name": "SRP Analytics Pipeline"}],
             "defined_type": "dataset"
@@ -145,12 +146,12 @@ jobs:
           EOF
           )
 
-          # Create the article (private by default)
+          # Create article
           RESPONSE=$(curl -s -X POST \
             -H "Authorization: token ${{ secrets.FIGSHARE_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d "$ARTICLE_DATA" \
-            "https://api.figshare.com/v2/account/articles")
+            "https://api.figshare.com/v2/account/projects/$PROJECT_ID/articles")
 
           # Extract article ID
           ARTICLE_ID=$(echo "$RESPONSE" | jq -r '.entity_id')

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -134,11 +134,10 @@ jobs:
           FIGSHARE_PROJECT_ID="${{ secrets.FIGSHARE_PROJECT_ID }}"
 
           # Define article metadata
-          ARTICLE_DATA=$(cat <<EOF
+          METADATA=$(cat <<EOF
           {
             "title": "SRP Analytics Database - ${TIMESTAMP}",
             "description": "Testing automated database build from commit ${COMMIT_SHA} on branch ${BRANCH_NAME}. Generated on ${TIMESTAMP}.",
-            # "tags": ["srp-analytics", "database"],
             "categories": [26965, 26968],
             "authors": [{"name": "SRP Analytics Pipeline"}],
             "defined_type": "dataset"
@@ -150,7 +149,7 @@ jobs:
           RESPONSE=$(curl -s -X POST \
             -H "Authorization: token ${{ secrets.FIGSHARE_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "$ARTICLE_DATA" \
+            -d "$METADATA" \
             "https://api.figshare.com/v2/account/projects/$PROJECT_ID/articles")
 
           # Extract article ID
@@ -163,6 +162,8 @@ jobs:
 
           echo "Created Figshare article with ID: $ARTICLE_ID"
           echo "article_id=$ARTICLE_ID" >> $GITHUB_OUTPUT
+
+  # metadata field: "tags": ["srp-analytics", "database"],
 
   artifact-test:
     needs:
@@ -207,8 +208,6 @@ jobs:
           FIGSHARE_TOKEN: ${{ secrets.FIGSHARE_TOKEN }}
           FIGSHARE_ENDPOINT: "https://api.figshare.com/v2"
           FIGSHARE_ARTICLE_ID: ${{ needs.create-figshare-article.outputs.article_id }}
-          # FIGSHARE_ARTICLE_ID: 26240471
-          # FIGSHARE_PROJECT_ID: 177459
           DATA_DIR: "srpAnalytics"
 #zipfiles push to figshare
 

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -25,7 +25,7 @@ jobs:
         run: docker pull sgosline/srp-bmd
       - name: Run bmd python command
         run: |
-          docker run -v $PWD:/tmp sgosline/srp-bmd --morpho /app/zfBmd/test_files/test_morphology.csv --lpr /app/zfBmd/test_files/test_behavioral.csv --output /tmp
+          docker run -v $PWD:/tmp sgosline/srp-zfbmd --morpho /app/zfBmd/test_files/test_morphology.csv --lpr /app/zfBmd/test_files/test_behavioral.csv --output /tmp
       - name: List files cwd
         run: ls -la
       - name: Move files

--- a/.github/workflows/database-update.yml
+++ b/.github/workflows/database-update.yml
@@ -131,7 +131,7 @@ jobs:
           TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
           COMMIT_SHA="${{ github.sha }}"
           BRANCH_NAME="${{ github.ref_name }}"
-          FIGSHARE_PROJECT_ID="${{ secrets.FIGSHARE_PROJECT_ID }}"
+          PROJECT_ID="${{ secrets.FIGSHARE_PROJECT_ID }}"
 
           # Define article metadata
           METADATA=$(cat <<EOF


### PR DESCRIPTION
# Summary

Updates build-database action to push files to figshare. Closes #99.

## Changelog

- BMD file generation now included in workflow. The BMD artifacts are now correctly piped to the upload step.
- Ubuntu version updated to `ubuntu-latest` to resolve issues with older Ubuntu version.
- Workflow now creates new figshare article in the appropriate figshare project each time an upload is triggered. Note that figshare project ID is now being stored as a github secret for security.